### PR TITLE
Fix argument order

### DIFF
--- a/Distribution/Helper.hs
+++ b/Distribution/Helper.hs
@@ -247,14 +247,14 @@ getSomeConfigState = ask >>= \(QueryEnv readProc progs projdir distdir) -> do
              , "ghc-merged-pkg-options"
              , "ghc-lang-options"
              , "licenses"
-             ] ++ progArgs
+             ]
 
   res <- liftIO $ do
     exe  <- findLibexecExe "cabal-helper-wrapper"
-    out <- readProc exe (projdir:distdir:args) ""
+    out <- readProc exe (progArgs ++ projdir:distdir:args) ""
     evaluate (read out) `E.catch` \(SomeException _) ->
       error $ concat ["getSomeConfigState", ": ", exe, " "
-                     , intercalate " " (map show $ distdir:args)
+                     , intercalate " " (map show $ progArgs ++ projdir:distdir:args)
                      , " (read failed)"]
 
   let [ Just (ChResponsePkgDbs pkgDbs),


### PR DESCRIPTION
The order of command line options to cabal-helper-wrapper is incorrect.

This PR will fix the following issue of ghc-mod.
I did not post this on kazu's ghc-mod Issues.

---

I has installed ghc 7.4.1 as the default ghc and ghc-pkg command. Other versions of ghc have installed under /usr/local directory.

Today, I build build ghc-mod 5.3.0.0 with ghc 7.8.4 and cabal sandbox, then it's succeeded. But, with such circumstances, ghc-mod tried and failed to open ghc-7.4.1's packages conf file in the sandbox directory, even though I specified ghc 7.8.4 by using --with-ghc, --with-ghc-pkg and --with-cabal options.

```
$ dist/build/ghc-mod/ghc-mod --with-ghc='/usr/local/ghc-7.8.4/bin/ghc' --with-cabal='cabal-1.20.0.3 --config-file=/home/yuga/.cabal/config-7.8.4' --with-ghc-pkg=/usr/local/ghc-7.8.4/bin/ghc-pkg check src/GHCMod.hs
ghc-pkg: /home/yuga/src/github/ghc-mod/.cabal-sandbox/x86_64-linux-ghc-7.4.1-packages.conf.d: openFile: does not exist (No such file or directory)
cabal-helper-wrapper: readProcess: ghc-pkg "list" "--simple-output" "Cabal" "--package-conf=/home/yuga/src/github/ghc-mod/.cabal-sandbox/x86_64-linux-ghc-7.4.1-packages.conf.d" (exit 1): failed
ghc-mod: readProcess: /home/yuga/src/github/ghc-mod/.cabal-sandbox/libexec/cabal-helper-wrapper "/home/yuga/src/github/ghc-mod" "/home/yuga/src/github/ghc-mod/dist" "package-db-stack" "entrypoints" "source-dirs" "ghc-options" "ghc-src-options" "ghc-pkg-options" "ghc-merged-pkg-options" "ghc-lang-options" "--with-ghc=/usr/local/ghc-7.8.4/bin/ghc" "--with-ghc-pkg=/usr/local/ghc-7.8.4/bin/ghc-pkg" "--with-cabal=cabal-1.20.0.3 --config-file=/home/yuga/.cabal/config-7.8.4" (exit 1): failed
```
