### PR TITLE
Fix an "empty IORef" message

### DIFF
--- a/CabalHelper/Main.hs
+++ b/CabalHelper/Main.hs
@@ -264,10 +264,10 @@ getLibrary pd = unsafePerformIO $ do
   readIORef lr
 
 getLibraryClbi pd lbi = unsafePerformIO $ do
-  lr <- newIORef (error "getLibraryClbi: empty IORef")
+  lr <- newIORef Nothing
 
   withLibLBI pd lbi $ \ lib clbi ->
-      writeIORef lr (lib,clbi)
+      writeIORef lr $ Just (lib,clbi)
 
   readIORef lr
 
@@ -365,18 +365,22 @@ removeInplaceDeps :: Verbosity
                   -> ComponentLocalBuildInfo
                   -> (ComponentLocalBuildInfo, GhcOptions)
 removeInplaceDeps v lbi pd clbi = let
-    (lib, libclbi) = getLibraryClbi pd lbi
-    libbi = libBuildInfo lib
-    liboutdir = componentOutDir lbi (CLib lib)
-    libopts = (componentGhcOptions normal lbi libbi libclbi liboutdir) {
-                                    ghcOptPackageDBs = []
-                                  }
-
     (ideps, deps) = partition isInplaceDep (componentPackageDeps clbi)
     hasIdeps = not $ null ideps
+    libopts =
+      case getLibraryClbi pd lbi of
+        Just (lib, libclbi) | hasIdeps ->
+          let
+            libbi = libBuildInfo lib
+            liboutdir = componentOutDir lbi (CLib lib)
+          in
+            (componentGhcOptions normal lbi libbi libclbi liboutdir) {
+                ghcOptPackageDBs = []
+            }
+        _ -> mempty
     clbi' = clbi { componentPackageDeps = deps }
 
-  in (clbi', if hasIdeps then libopts else mempty)
+  in (clbi', libopts)
 
  where
    isInplaceDep :: (InstalledPackageId, PackageId) -> Bool


### PR DESCRIPTION
When you state a dependency on the library in the current package, but there
_isn't_ a library in the current package, cabal-helper previously died with the
message `getLibraryClbi: empty IORef`. It should now stop doing that.

(Even though this means your package is broken, the unfriendly error message is
probably not the right thing to do.)
