### PR TITLE
Make it possible to use `flags` query without setup-config.

### DIFF
--- a/CabalHelper/Main.hs
+++ b/CabalHelper/Main.hs
@@ -183,10 +183,6 @@ main = do
 
   print =<< flip mapM cmds $$ \cmd -> do
   case cmd of
-    "flags":[] -> do
-      return $ Just $ ChResponseFlags $ sort $
-        map (flagName' &&& flagDefault) $ genPackageFlags gpd
-
     "config-flags":[] -> do
       return $ Just $ ChResponseFlags $ sort $
         map (first unFlagName') $ configConfigurationsFlags $ configFlags lbi


### PR DESCRIPTION
I thought it would be nice to get a list of package flags before configuring it.
