### PR TITLE
Add "print-helper-prepared" command.

### DIFF
--- a/CabalHelper/Compile.hs
+++ b/CabalHelper/Compile.hs
@@ -413,6 +413,9 @@ errorInstallCabal cabalVer _distdir = panic $ printf "\
  where
    sver = showVersion cabalVer
 
+helperPrepared :: Version -> IO Bool
+helperPrepared compCabalVersion = isJust <$> cachedExe compCabalVersion
+
 cachedExe :: Version -> IO (Maybe FilePath)
 cachedExe compCabalVersion = do
    exe <- exePath (Right compCabalVersion)

--- a/Distribution/Helper.hs
+++ b/Distribution/Helper.hs
@@ -65,6 +65,7 @@ module Distribution.Helper (
   -- * Managing @dist/@
   , prepare
   , prepare'
+  , isPrepared
   , reconfigure
   , writeAutogenFiles
   , writeAutogenFiles'
@@ -364,6 +365,13 @@ prepare readProc projdir distdir = liftIO $ do
 prepare' :: MonadIO m => QueryEnv -> m ()
 prepare' qe =
   liftIO $ void $ invokeHelper qe []
+
+isPrepared :: MonadIO m => QueryEnv -> m Bool
+isPrepared qe = liftIO $ do
+  out <- invokeHelper qe ["print-exe-prepared"]
+  return $ case out of
+    Left _ -> False
+    Right r -> read r
 
 writeAutogenFiles :: MonadIO m
                   => (FilePath -> [String] -> String -> IO String)


### PR DESCRIPTION
This command checks if helper executable is already compiled for a given cabal version.