### PR TITLE
[WIP] Adaptations to compile with new cabal versions

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -22,6 +22,7 @@ import qualified Distribution.Simple.InstallDirs as ID
 import Distribution.Simple.LocalBuildInfo
 import Distribution.Simple.Program
 import Distribution.PackageDescription
+import Distribution.Types.UnqualComponentName
 
 import qualified Data.Map as M
 import Data.Map (Map)
@@ -96,9 +97,9 @@ xInstallTarget pd lbi cf fn = do
         copydest  = fromFlag (copyDest cf)
         verbosity = fromFlag (copyVerbosity cf)
         InstallDirs { bindir, libexecdir } = absoluteInstallDirs pd lbi' copydest
-        progprefix = substPathTemplate (packageId pd) lbi (progPrefix lbi)
-        progsuffix = substPathTemplate (packageId pd) lbi (progSuffix lbi)
-        fixedExeBaseName = progprefix ++ exeName exe ++ progsuffix
+        progprefix = substPathTemplate (packageId pd) lbi (localUnitId lbi) (progPrefix lbi)
+        progsuffix = substPathTemplate (packageId pd) lbi (localUnitId lbi) (progSuffix lbi)
+        fixedExeBaseName = progprefix ++ unUnqualComponentName (exeName exe) ++ progsuffix
 
         fixedExeFileName = bindir </> fixedExeBaseName <.> exeExtension
         newExeFileName   = libexecdir </> fixedExeBaseName <.> exeExtension

--- a/cabal-helper.cabal
+++ b/cabal-helper.cabal
@@ -45,7 +45,7 @@ source-repository head
 
 custom-setup
   setup-depends:         base
-                       , Cabal (>= 1.14 && < 1.25) || (>= 2.1 && < 2.2)
+                       , Cabal >= 2.0 && < 2.1
                        , containers
                        , filepath
                        , directory
@@ -61,7 +61,7 @@ library
   default-language:    Haskell2010
   ghc-options:         -Wall
   build-depends:       base          < 5    && >= 4.5
-                     , Cabal         < 2.2  && >= 2.1     || < 1.26 && >= 1.14
+                     , Cabal         < 2.1  && >= 2.0
                      , directory     < 1.4  && >= 1.1.0.2
                      , filepath      < 1.5  && >= 1.3.0.0
                      , transformers  < 0.6  && >= 0.3.0.0
@@ -86,7 +86,7 @@ executable cabal-helper-wrapper
   scope:               private
   x-scope:             private
   build-depends:       base             < 5    && >= 4.5
-                     , Cabal            < 2.2  && >= 2.1     || < 1.26 && >= 1.14
+                     , Cabal            < 2.1  && >= 2.0
                      , bytestring       < 0.11 && >= 0.9.2.1
                      , directory        < 1.4  && >= 1.1.0.2
                      , filepath         < 1.5  && >= 1.3.0.0


### PR DESCRIPTION
I'd like to get ghc-mod working with 8.2.1 and it seems that the first step is getting cabal-helper working with the new cabal versions.

It's mostly compiling with this change, but I've dropped support for older cabal versions, and I'm guessing we don't really want that. Should I go CPP all the way and make it compatible?

Other than that, the build it fails with 

```
internal error: the package description contains no component corresponding to CLibName
CallStack (from HasCallStack):
  error, called at .\Distribution\Types\PackageDescription.hs:414:7 in Cabal-2.0.0.2-Jknk4LInQ2T7HuZsv1rhlg:Distribution.Types.PackageDescription
'cabal copy' failed.  Error message:

--  While building package cabal-helper-0.7.3.0 using:
      C:\Users\darwi\Projects\cabal-helper\.stack-work\dist\e53504d9\setup\setup --builddir=.stack-work\dist\e53504d9 copy
    Process exited with code: ExitFailure 1

Possible causes of this issue:
* No module named "Main". The 'main-is' source file should usually have a header indicating that it's a 'Main' module.
* The Setup.hs file is changing the installation target dir.
```

while linking (or maybe just after linking). Since this does some funky stuff with `Setup.hs` I thought that maybe it's the expected behavior. 