### PR TITLE
Preprocess path

### DIFF
--- a/src/CabalHelper/Runtime/Main.hs
+++ b/src/CabalHelper/Runtime/Main.hs
@@ -530,7 +530,10 @@ componentOptions' (lbi, v, distdir) inplaceFlag flags rf f = do
            opts = componentGhcOptions normal lbi bi clbi' outdir
 #if CH_MIN_VERSION_Cabal(2,0,0)
            -- Add preprocessor output directory
-           opts'' = opts { ghcOptSourcePath = (ghcOptSourcePath opts) <> (toNubListR [outdir ++ "-tmp"]) }
+           preprocessorDir = case splitDirectories outdir of
+                               [] -> mempty -- Should never happen
+                               ds -> toNubListR [outdir </> last ds ++ "-tmp"]
+           opts'' = opts { ghcOptSourcePath = (ghcOptSourcePath opts) <> preprocessorDir }
 #else
            opts'' = opts
 #endif

--- a/src/CabalHelper/Runtime/Main.hs
+++ b/src/CabalHelper/Runtime/Main.hs
@@ -528,7 +528,13 @@ componentOptions' (lbi, v, distdir) inplaceFlag flags rf f = do
                                [] -> removeInplaceDeps v lbi pd clbi
 #endif
            opts = componentGhcOptions normal lbi bi clbi' outdir
-           opts' = f opts
+#if CH_MIN_VERSION_Cabal(2,0,0)
+           -- Add preprocessor output directory
+           opts'' = opts { ghcOptSourcePath = (ghcOptSourcePath opts) <> (toNubListR [outdir ++ "-tmp"]) }
+#else
+           opts'' = opts
+#endif
+           opts' = f opts''
 
          in rf lbi v $ nubPackageFlags $ opts' `mappend` adopts
 


### PR DESCRIPTION
It seems that from cabal 2.0 onward, the output of preprocessors run on the source are stored in a different directory.

This directory needs to be included too when invoking GHC, which this patch does.