### PR TITLE
(0.8 series) ghc 8.6.5 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 dist/
+dist-newstyle/
+.ghc.environment*
 *~
 /.cabal-sandbox/
 add-source-timestamps

--- a/cabal-helper.cabal
+++ b/cabal-helper.cabal
@@ -113,7 +113,7 @@ library
   if !os(windows)
     build-depends:     unix             < 2.8  && >= 2.5.1.1
   build-depends:       unix-compat      < 0.6  && >= 0.4.3.1
-                     , semigroupoids    < 5.3  && >= 5.2
+                     , semigroupoids    < 5.4  && >= 5.2
 
 
 

--- a/cabal-helper.cabal
+++ b/cabal-helper.cabal
@@ -154,7 +154,7 @@ executable cabal-helper-wrapper
                      , process          < 1.7  && >= 1.1.0.1
                      , pretty-show      < 1.9  && >= 1.8.1
                      , text             < 1.3  && >= 1.0.0.0
-                     , template-haskell < 2.14 && >= 2.7.0.0
+                     , template-haskell < 2.15 && >= 2.7.0.0
                      , temporary        < 1.3  && >= 1.2.1
                      , transformers     < 0.6  && >= 0.3.0.0
   if !os(windows)
@@ -202,7 +202,7 @@ test-suite compile-test
                      , process          < 1.7  && >= 1.1.0.1
                      , pretty-show      < 1.9  && >= 1.8.1
                      , text             < 1.3  && >= 1.0.0.0
-                     , template-haskell < 2.14 && >= 2.7.0.0
+                     , template-haskell < 2.15 && >= 2.7.0.0
                      , temporary        < 1.3  && >= 1.2.1
                      , transformers     < 0.6  && >= 0.3.0.0
   if !os(windows)
@@ -218,7 +218,7 @@ test-suite ghc-session
   hs-source-dirs:      tests
   ghc-options:         -Wall
   build-depends:       base             < 5    && >= 4.7
-                     , ghc              < 8.5  && >= 7.8
+                     , ghc              < 8.8  && >= 7.8
                      , ghc-paths        < 0.2  && >= 0.1.0.9
                      , cabal-helper
 
@@ -253,7 +253,7 @@ test-suite ghc-session
                      , process          < 1.7  && >= 1.1.0.1
                      , pretty-show      < 1.9  && >= 1.8.1
                      , text             < 1.3  && >= 1.0.0.0
-                     , template-haskell < 2.14 && >= 2.7.0.0
+                     , template-haskell < 2.15 && >= 2.7.0.0
                      , temporary        < 1.3  && >= 1.2.1
                      , transformers     < 0.6  && >= 0.3.0.0
   if !os(windows)

--- a/tests/CompileTest.hs
+++ b/tests/CompileTest.hs
@@ -109,6 +109,7 @@ allCabalVersions ghc_ver = let
          , "2.0.1.1"
          , "2.2.0.0"
          , "2.2.0.1"
+         , "2.4.1.0"
          ]
 
     constraint :: VersionRange
@@ -130,6 +131,7 @@ allCabalVersions ghc_ver = let
             , ("8.2.2", ">= 2.0.0.2       ")
             , ("8.4.1", ">= 2.0.0.2       ")
             , ("8.4.2", ">= 2.2.0.1       ")
+            , ("8.6.5", ">= 2.4.0.1       ")
             ]
   in
     reverse $ filter (flip withinRange'CH constraint) cabal_versions


### PR DESCRIPTION
Adding support for GHC 8.6.5 into **0.8-series** branch.

Looks like it's hard to pass `cabal` errors due to known issue with `transformers`: https://gitlab.haskell.org/ghc/ghc/issues/16199. Seems to be resolved in `8.8.1-alpha` and actually some hotfix was applied in `8.6.5`.

- `v1-` flow (see below) passed.
```
cabal v1-build
cabal v1-install
cabal v1-test
```

- `v2-` flow (see below) also passed.
```
cabal v2-build --enable-tests
cabal v2-install --symlink-bindir=$HOME/.local/bin
cabal v2-test
```

The only topic I am worrying about is Gitlab pipeline. I have not previously experienced with this Gitlab and its CI/CD capabilities. @DanielG, could you please suggest, is it necessary for this PR?