### PR TITLE
Relax lower bound of Win32 down to the version used by ghc-8.2.2

### DIFF
--- a/cabal-helper.cabal
+++ b/cabal-helper.cabal
@@ -122,7 +122,7 @@ common build-deps
                      , transformers     < 0.6  && >= 0.5.2.0
                      , utf8-string      < 1.1  && >= 1.0.1.1
   if os(windows)
-    build-depends:     Win32            < 2.9  && >= 2.8.3.0
+    build-depends:     Win32            < 2.9  && >= 2.5.4.1
   else
     build-depends:     unix             < 2.8  && >= 2.7.2.1
   build-depends:       unix-compat      < 0.6  && >= 0.4.3.1


### PR DESCRIPTION
That is the ghc minimum version used by haskell-ide-engine (see https://github.com/mpickering/haskell-ide-engine/pull/26#issuecomment-542032107)