### PR TITLE
Discover v2 cabal projects

### DIFF
--- a/lib/Distribution/Helper/Discover.hs
+++ b/lib/Distribution/Helper/Discover.hs
@@ -55,11 +55,8 @@ findProjects dir = execWriterT $ do
   whenM (liftIO $ doesFileExist stackYaml) $
     tell [Ex $ ProjLocStackYaml stackYaml]
 
-  join $ traverse (tell . pure . Ex . ProjLocV2Dir . takeDirectory) <$>
-    liftIO (findCabalFile dir)
-
-  join $ traverse (tell . pure . Ex . ProjLocV1Dir . takeDirectory) <$>
-    liftIO (findCabalFile dir)
+  maybeCabalDir <- liftIO (fmap takeDirectory <$> findCabalFile dir)
+  forM_ [Ex . ProjLocV2Dir, Ex . ProjLocV1Dir] $ \proj -> traverse (tell . pure . proj) maybeCabalDir
 
 
 -- | @getDefaultDistDir pl@. Get the default dist-dir for the given project.

--- a/lib/Distribution/Helper/Discover.hs
+++ b/lib/Distribution/Helper/Discover.hs
@@ -34,7 +34,6 @@ import System.FilePath
 
 import CabalHelper.Compiletime.Types
 import CabalHelper.Compiletime.Cabal
-import CabalHelper.Compiletime.Program.CabalInstall
 
 -- | @findProjects dir@. Find available project instances in @dir@.
 --
@@ -57,12 +56,8 @@ findProjects dir = execWriterT $ do
   whenM (liftIO $ doesFileExist stackYaml) $
     tell [Ex $ ProjLocStackYaml stackYaml]
 
-  cabalVersion <- liftIO $ let ?verbose = (<=0)
-                               ?progs = defaultPrograms
-                             in cabalInstallVersion
-  when (cabalInstallVer cabalVersion >= makeVersion [3,0,0,0]) $ void $
-    join $ traverse (tell . pure . Ex . ProjLocV2Dir . takeDirectory) <$>
-      liftIO (findCabalFile dir)
+  join $ traverse (tell . pure . Ex . ProjLocV2Dir . takeDirectory) <$>
+    liftIO (findCabalFile dir)
 
   join $ traverse (tell . pure . Ex . ProjLocV1Dir . takeDirectory) <$>
     liftIO (findCabalFile dir)

--- a/lib/Distribution/Helper/Discover.hs
+++ b/lib/Distribution/Helper/Discover.hs
@@ -28,11 +28,13 @@ module Distribution.Helper.Discover
   ) where
 
 import Control.Monad.Writer
+import Data.Version
 import System.Directory
 import System.FilePath
 
 import CabalHelper.Compiletime.Types
 import CabalHelper.Compiletime.Cabal
+import CabalHelper.Compiletime.Program.CabalInstall
 
 -- | @findProjects dir@. Find available project instances in @dir@.
 --
@@ -54,6 +56,14 @@ findProjects dir = execWriterT $ do
   let stackYaml = dir </> "stack.yaml"
   whenM (liftIO $ doesFileExist stackYaml) $
     tell [Ex $ ProjLocStackYaml stackYaml]
+
+  cabalVersion <- liftIO $ let ?verbose = (<=0)
+                               ?progs = defaultPrograms
+                             in cabalInstallVersion
+  when (cabalInstallVer cabalVersion >= makeVersion [3,0,0,0]) $ void $
+    join $ traverse (tell . pure . Ex . ProjLocV2Dir . takeDirectory) <$>
+      liftIO (findCabalFile dir)
+
   join $ traverse (tell . pure . Ex . ProjLocV1Dir . takeDirectory) <$>
     liftIO (findCabalFile dir)
 

--- a/lib/Distribution/Helper/Discover.hs
+++ b/lib/Distribution/Helper/Discover.hs
@@ -28,7 +28,6 @@ module Distribution.Helper.Discover
   ) where
 
 import Control.Monad.Writer
-import Data.Version
 import System.Directory
 import System.FilePath
 


### PR DESCRIPTION
Since `cabal build` now defaults to a v2 build, it would make sense to
detect a v2 project even if there is no cabal.project file.