### PR TITLE
Explicitly state package in component in cabal v2-build

### DIFF
--- a/lib/Distribution/Helper.hs
+++ b/lib/Distribution/Helper.hs
@@ -499,10 +499,15 @@ buildProjectTarget qe mu stage = do
           SCV2 -> do
             targets <- return $ case mu of
               Nothing -> ["all"]
-              Just Unit{uImpl} -> concat
+              Just Unit{uImpl,uPackage} -> concat
                 [ if uiV2OnlyDependencies uImpl
                     then ["--only-dependencies"] else []
-                , uiV2Components uImpl
+                -- explicitly add the package name to the component
+                -- this prevents ambiguous component errors, e.g: for component test:foo
+                -- cabal: Ambiguous target 'test:foo'. It could be:
+                -- A:test:foo (component)
+                -- B:test:foo (component)
+                , map ((pPackageName uPackage <> ":") <>) (uiV2Components uImpl)
                 ]
             case qeProjLoc of
               ProjLocV2File {plCabalProjectFile} ->

--- a/lib/Distribution/Helper/Discover.hs
+++ b/lib/Distribution/Helper/Discover.hs
@@ -55,11 +55,8 @@ findProjects dir = execWriterT $ do
   whenM (liftIO $ doesFileExist stackYaml) $
     tell [Ex $ ProjLocStackYaml stackYaml]
 
-  join $ traverse (tell . pure . Ex . ProjLocV2Dir . takeDirectory) <$>
-    liftIO (findCabalFile dir)
-
-  join $ traverse (tell . pure . Ex . ProjLocV1Dir . takeDirectory) <$>
-    liftIO (findCabalFile dir)
+  maybeCabalDir <- liftIO (fmap takeDirectory <$> findCabalFile dir)
+  forM_ [Ex . ProjLocV2Dir, Ex . ProjLocV1Dir] $ \proj -> traverse (tell . pure . proj) maybeCabalDir
 
 
 -- | @getDefaultDistDir pl@. Get the default dist-dir for the given project.

--- a/lib/Distribution/Helper/Discover.hs
+++ b/lib/Distribution/Helper/Discover.hs
@@ -34,7 +34,6 @@ import System.FilePath
 
 import CabalHelper.Compiletime.Types
 import CabalHelper.Compiletime.Cabal
-import CabalHelper.Compiletime.Program.CabalInstall
 
 -- | @findProjects dir@. Find available project instances in @dir@.
 --
@@ -57,12 +56,8 @@ findProjects dir = execWriterT $ do
   whenM (liftIO $ doesFileExist stackYaml) $
     tell [Ex $ ProjLocStackYaml stackYaml]
 
-  cabalVersion <- liftIO $ let ?verbose = (<=0)
-                               ?progs = defaultPrograms
-                             in cabalInstallVersion
-  when (cabalInstallVer cabalVersion >= makeVersion [3,0,0,0]) $ void $
-    join $ traverse (tell . pure . Ex . ProjLocV2Dir . takeDirectory) <$>
-      liftIO (findCabalFile dir)
+  join $ traverse (tell . pure . Ex . ProjLocV2Dir . takeDirectory) <$>
+    liftIO (findCabalFile dir)
 
   join $ traverse (tell . pure . Ex . ProjLocV1Dir . takeDirectory) <$>
     liftIO (findCabalFile dir)

--- a/lib/Distribution/Helper/Discover.hs
+++ b/lib/Distribution/Helper/Discover.hs
@@ -28,11 +28,13 @@ module Distribution.Helper.Discover
   ) where
 
 import Control.Monad.Writer
+import Data.Version
 import System.Directory
 import System.FilePath
 
 import CabalHelper.Compiletime.Types
 import CabalHelper.Compiletime.Cabal
+import CabalHelper.Compiletime.Program.CabalInstall
 
 -- | @findProjects dir@. Find available project instances in @dir@.
 --
@@ -54,6 +56,14 @@ findProjects dir = execWriterT $ do
   let stackYaml = dir </> "stack.yaml"
   whenM (liftIO $ doesFileExist stackYaml) $
     tell [Ex $ ProjLocStackYaml stackYaml]
+
+  cabalVersion <- liftIO $ let ?verbose = (<=0)
+                               ?progs = defaultPrograms
+                             in cabalInstallVersion
+  when (cabalInstallVer cabalVersion >= makeVersion [3,0,0,0]) $ void $
+    join $ traverse (tell . pure . Ex . ProjLocV2Dir . takeDirectory) <$>
+      liftIO (findCabalFile dir)
+
   join $ traverse (tell . pure . Ex . ProjLocV1Dir . takeDirectory) <$>
     liftIO (findCabalFile dir)
 

--- a/lib/Distribution/Helper/Discover.hs
+++ b/lib/Distribution/Helper/Discover.hs
@@ -28,7 +28,6 @@ module Distribution.Helper.Discover
   ) where
 
 import Control.Monad.Writer
-import Data.Version
 import System.Directory
 import System.FilePath
 


### PR DESCRIPTION
This fixes scenarios such as:
  cabal: Ambiguous target 'test:foo'. It could be:
  A:test:foo (component)
  B:test:foo (component)

Branch based upon #84 