### PR TITLE
Enable tests and benchmarks for stack

### DIFF
--- a/lib/Distribution/Helper.hs
+++ b/lib/Distribution/Helper.hs
@@ -518,15 +518,16 @@ buildProjectTarget qe mu stage = do
              } -> do
       let projdir = plStackProjectDir qeProjLoc
       let workdir_opts = Stack.workdirArg qe
-      let opts =  workdir_opts ++
-                  [ "--stack-yaml="++plStackYaml, "build", "."
-                  , "--test", "--bench", "--no-run-tests", "--no-run-benchmarks"
-                  ] ++ stage_opts
+      let opts target =
+            workdir_opts ++
+            [ "--stack-yaml="++plStackYaml, "build", target
+            , "--test", "--bench", "--no-run-tests", "--no-run-benchmarks"
+            ] ++ stage_opts
       case mu of
         Just Unit{uPackage=Package{pSourceDir}} ->
-          Stack.callStackCmd qe (Just pSourceDir) opts
+          Stack.callStackCmd qe (Just pSourceDir) (opts ".")
         Nothing ->
-          Stack.callStackCmd qe (Just projdir) opts
+          Stack.callStackCmd qe (Just projdir) (opts "")
 
 getFileModTime :: FilePath -> IO (FilePath, EpochTime)
 getFileModTime f = do

--- a/lib/Distribution/Helper.hs
+++ b/lib/Distribution/Helper.hs
@@ -518,17 +518,15 @@ buildProjectTarget qe mu stage = do
              } -> do
       let projdir = plStackProjectDir qeProjLoc
       let workdir_opts = Stack.workdirArg qe
+      let opts =  workdir_opts ++
+                  [ "--stack-yaml="++plStackYaml, "build", "."
+                  , "--test", "--bench", "--no-run-tests", "--no-run-benchmarks"
+                  ] ++ stage_opts
       case mu of
         Just Unit{uPackage=Package{pSourceDir}} ->
-          Stack.callStackCmd qe (Just pSourceDir) $
-            workdir_opts ++
-            [ "--stack-yaml="++plStackYaml, "build", "."
-            ] ++ stage_opts
+          Stack.callStackCmd qe (Just pSourceDir) opts
         Nothing ->
-          Stack.callStackCmd qe (Just projdir) $
-            workdir_opts ++
-            [ "--stack-yaml="++plStackYaml, "build"
-            ] ++ stage_opts
+          Stack.callStackCmd qe (Just projdir) opts
 
 getFileModTime :: FilePath -> IO (FilePath, EpochTime)
 getFileModTime f = do


### PR DESCRIPTION
* In [hie we detected](https://github.com/haskell/haskell-ide-engine/issues/1564) that, if you did not a `stack build --test` we were not able to load the ghc flags using cabal-helper+hie-bios
* This pr adds `--test --benchmarks` to all stack stages triggered by `cabal-helper` to ensure all components are enabled (with `--no-run.tests`and `no-run-benchamrks` to avoid unwanted work)
* I'v tested manually that the error is not hrowed with this version