### PR TITLE
Fix pattern errors in windows

### DIFF
--- a/cabal-helper.cabal
+++ b/cabal-helper.cabal
@@ -110,7 +110,7 @@ common build-deps
   build-depends:       unix-compat      < 0.6  && >= 0.4.3.1
 
   if flag(dev)
-    ghc-options:       -Wall
+    ghc-options:       -Wall -fwarn-incomplete-uni-patterns
 
 
 common c-h-internal
@@ -174,14 +174,14 @@ test-suite compile-test
   main-is:             CompileTest.hs
   other-modules:       TestOptions
   hs-source-dirs:      tests
-  ghc-options:         -Wall
+  ghc-options:         -Wall -fwarn-incomplete-uni-patterns
 
 test-suite programs-test
   import:              build-deps, extensions, c-h-internal
   type:                exitcode-stdio-1.0
   main-is:             ProgramsTest.hs
   hs-source-dirs:      tests
-  ghc-options:         -Wall
+  ghc-options:         -Wall -fwarn-incomplete-uni-patterns
   build-depends:       pretty-show
 
 test-suite ghc-session
@@ -190,7 +190,7 @@ test-suite ghc-session
   main-is:             GhcSession.hs
   other-modules:       TestOptions
   hs-source-dirs:      tests
-  ghc-options:         -Wall
+  ghc-options:         -Wall -fwarn-incomplete-uni-patterns
   build-depends:       ghc              < 8.9  && >= 8.0.2
                      , pretty-show      < 1.9  && >= 1.8.1
 
@@ -199,7 +199,7 @@ test-suite examples
   type:                exitcode-stdio-1.0
   main-is:             Examples.hs
   hs-source-dirs:      tests
-  ghc-options:         -Wall
+  ghc-options:         -Wall -fwarn-incomplete-uni-patterns
 
 executable cabal-helper-main
   default-language:    Haskell2010
@@ -220,7 +220,7 @@ executable cabal-helper-main
   else
     buildable:         False
 
-  ghc-options:         -Wall -fno-warn-unused-imports
+  ghc-options:         -Wall -fno-warn-unused-imports -fwarn-incomplete-uni-patterns
   build-depends:       base             < 5    && >= 4.9.1.0
                      , Cabal
                      , containers

--- a/src/CabalHelper/Compiletime/CompPrograms.hs
+++ b/src/CabalHelper/Compiletime/CompPrograms.hs
@@ -92,8 +92,11 @@ patchBuildToolProgs SStack progs = do
 createProgSymlink :: FilePath -> FilePath -> IO ()
 createProgSymlink bindir target
   | [exe] <- splitPath target = do
-    Just exe_path <- findExecutable exe
-    createSymbolicLink exe_path (bindir </> takeFileName target)
-  | otherwise = do
-    cwd <- getCurrentDirectory
-    createSymbolicLink (cwd </> target) (bindir </> takeFileName target)
+    mb_exe_path <- findExecutable exe
+    case mb_exe_path of
+      Just exe_path -> createSymbolicLink exe_path (bindir </> takeFileName target)
+      Nothing -> createSymLinkFromCwd
+  | otherwise = createSymLinkFromCwd
+  where createSymLinkFromCwd = do
+          cwd <- getCurrentDirectory
+          createSymbolicLink (cwd </> target) (bindir </> takeFileName target)

--- a/src/CabalHelper/Compiletime/CompPrograms.hs
+++ b/src/CabalHelper/Compiletime/CompPrograms.hs
@@ -11,6 +11,7 @@ import System.IO.Temp
 
 import CabalHelper.Compiletime.Types
 import CabalHelper.Compiletime.Cabal (getCabalVerbosity)
+import CabalHelper.Shared.Common (panicIO)
 import Symlink (createSymbolicLink)
 
 import Distribution.Simple.GHC as GHC (configure)
@@ -96,8 +97,8 @@ createProgSymlink required bindir target
     mb_exe_path <- findExecutable exe
     case mb_exe_path of
       Just exe_path -> createSymbolicLink exe_path (bindir </> takeFileName target)
-      Nothing -> when required $ error $ "Error trying to create symlink to " ++ target ++ ": "
-                                       ++ exe ++ " executable not found."
+      Nothing -> when required $ panicIO $ "Error trying to create symlink to '" ++ target ++ "': "
+                                        ++ "'" ++ exe ++ "'" ++ " executable not found."
   | otherwise = do
     cwd <- getCurrentDirectory
     createSymbolicLink (cwd </> target) (bindir </> takeFileName target)

--- a/src/CabalHelper/Compiletime/Program/Stack.hs
+++ b/src/CabalHelper/Compiletime/Program/Stack.hs
@@ -85,7 +85,7 @@ paths qe@QueryEnv{qeProjLoc=ProjLocStackYaml stack_yaml} cwd
     workdirArg qe ++ [ "path", "--stack-yaml="++stack_yaml ]
   return $ \k -> let Just x = lookup k $ map split $ lines out in x
   where
-    split l = let (key, ' ' : val) = span (not . isSpace) l in (key, val)
+    split l = let (key, val) = break isSpace l in (key, dropWhile isSpace val)
 
 listPackageCabalFiles :: QueryEnvI c 'Stack -> IO [CabalFile]
 listPackageCabalFiles qe@QueryEnv{qeProjLoc}


### PR DESCRIPTION
* Detected in the azure ci of haskell-ide-engine
* I am pretty sure one of the errors (in `createProgSymlink`) is fixed:
  * azure runs windows+stack+ghc-8.6.4 with failing tests using cabal-helper master: 
     * https://dev.azure.com/jneira/haskell-ide-engine/_build/results?buildId=590&view=results
     * https://dev.azure.com/jneira/haskell-ide-engine/_build/results?buildId=595&view=results
     * and finally https://dev.azure.com/jneira/haskell-ide-engine/_build/results?buildId=601&view=results
  * azure runs using this patch with the test suite green
     * https://dev.azure.com/jneira/haskell-ide-engine/_build/results?buildId=600&view=results
     * https://dev.azure.com/jneira/haskell-ide-engine/_build/results?buildId=589&view=results
  * It reuses an existing fallback that seems to work in the missing pattern case
* The other one (`Stack.paths`) is intermittent and this patch *does not* fix it, only move it up. I think it should be handle there. However it removes the missing pattern and makes it a little bit more resilient against `stack path` format changes. I think the error is triggered cause the `stack path` output is an error but i am not able to replicate it in local.

* I've added `-fwarn-incomplete-uni-patterns` to cabal config but maybe you are fine without them, i will remove in that case
* Fixes #91