### PR TITLE
Turn private library into common stanza

### DIFF
--- a/cabal-helper.cabal
+++ b/cabal-helper.cabal
@@ -113,9 +113,9 @@ common build-deps
     ghc-options:       -Wall
 
 
-library c-h-internal
+common c-h-internal
   import:             build-deps, extensions
-  exposed-modules:
+  other-modules:
                        CabalHelper.Compiletime.Cabal
                        CabalHelper.Compiletime.CompPrograms
                        CabalHelper.Compiletime.Compat.Environment
@@ -148,7 +148,7 @@ library c-h-internal
   hs-source-dirs:      src
 
 library
-  import:              build-deps, extensions
+  import:              build-deps, extensions, c-h-internal
   exposed-modules:     Distribution.Helper
                        Distribution.Helper.Discover
   other-modules:
@@ -156,28 +156,25 @@ library
   autogen-modules:
                        Paths_cabal_helper
   hs-source-dirs:      lib
-  build-depends:       c-h-internal
 
 test-suite compile-test
-  import:              build-deps, extensions
+  import:              build-deps, extensions, c-h-internal
   type:                exitcode-stdio-1.0
   main-is:             CompileTest.hs
   other-modules:       TestOptions
   hs-source-dirs:      tests
   ghc-options:         -Wall
-  build-depends:       c-h-internal
 
 test-suite programs-test
-  import:              build-deps, extensions
+  import:              build-deps, extensions, c-h-internal
   type:                exitcode-stdio-1.0
   main-is:             ProgramsTest.hs
   hs-source-dirs:      tests
   ghc-options:         -Wall
-  build-depends:       c-h-internal
-                     , pretty-show
+  build-depends:       pretty-show
 
 test-suite ghc-session
-  import:              build-deps, extensions
+  import:              build-deps, extensions, c-h-internal
   type:                exitcode-stdio-1.0
   main-is:             GhcSession.hs
   other-modules:       TestOptions
@@ -186,7 +183,6 @@ test-suite ghc-session
   build-depends:       ghc              < 8.9  && >= 8.0.2
                      , pretty-show      < 1.9  && >= 1.8.1
                      , cabal-helper
-                     , c-h-internal
 
 test-suite examples
   import:              build-deps, extensions

--- a/cabal-helper.cabal
+++ b/cabal-helper.cabal
@@ -148,7 +148,7 @@ common c-h-internal
   hs-source-dirs:      src
 
 library
-  import:              build-deps, extensions, c-h-internal
+  import:              c-h-internal
   exposed-modules:     Distribution.Helper
                        Distribution.Helper.Discover
   other-modules:
@@ -158,7 +158,7 @@ library
   hs-source-dirs:      lib
 
 test-suite compile-test
-  import:              build-deps, extensions, c-h-internal
+  import:              c-h-internal
   type:                exitcode-stdio-1.0
   main-is:             CompileTest.hs
   other-modules:       TestOptions
@@ -166,7 +166,7 @@ test-suite compile-test
   ghc-options:         -Wall
 
 test-suite programs-test
-  import:              build-deps, extensions, c-h-internal
+  import:              c-h-internal
   type:                exitcode-stdio-1.0
   main-is:             ProgramsTest.hs
   hs-source-dirs:      tests
@@ -174,15 +174,16 @@ test-suite programs-test
   build-depends:       pretty-show
 
 test-suite ghc-session
-  import:              build-deps, extensions, c-h-internal
+  import:              c-h-internal
   type:                exitcode-stdio-1.0
   main-is:             GhcSession.hs
   other-modules:       TestOptions
-  hs-source-dirs:      tests
+                       Distribution.Helper
+                       Distribution.Helper.Discover
+  hs-source-dirs:      tests, lib
   ghc-options:         -Wall
   build-depends:       ghc              < 8.9  && >= 8.0.2
                      , pretty-show      < 1.9  && >= 1.8.1
-                     , cabal-helper
 
 test-suite examples
   import:              build-deps, extensions


### PR DESCRIPTION
Private libraries have a bunch of bugs in cabal currently:
* https://github.com/haskell/cabal/issues/6211
* https://github.com/haskell/cabal/issues/6483

and devs of haskell-ide-engine are encountering this bug frequently.
To mitigate this issue, remove usage of private libraries and use
a common stanza to have the same re-use as before.

This change can be undone when the mentioned issues have been resolved.

closes #94 
cc @jneira 