### PR TITLE
Turn private library into common stanza

### DIFF
--- a/cabal-helper.cabal
+++ b/cabal-helper.cabal
@@ -113,9 +113,9 @@ common build-deps
     ghc-options:       -Wall
 
 
-library c-h-internal
+common c-h-internal
   import:             build-deps, extensions
-  exposed-modules:
+  other-modules:
                        CabalHelper.Compiletime.Cabal
                        CabalHelper.Compiletime.CompPrograms
                        CabalHelper.Compiletime.Compat.Environment
@@ -139,7 +139,7 @@ library c-h-internal
                        Paths_cabal_helper
   autogen-modules:
                        Paths_cabal_helper
-  exposed-modules:
+  other-modules:
                        Symlink
   if os(windows)
     hs-source-dirs:    os/win
@@ -147,8 +147,19 @@ library c-h-internal
     hs-source-dirs:    os/posix
   hs-source-dirs:      src
 
+common c-h-lib
+  import:             build-deps, extensions, c-h-internal
+  other-modules:
+                       Distribution.Helper
+                       Distribution.Helper.Discover
+  other-modules:
+                       Paths_cabal_helper
+  autogen-modules:
+                       Paths_cabal_helper
+  hs-source-dirs:      lib
+
 library
-  import:              build-deps, extensions
+  import:              build-deps, extensions, c-h-internal
   exposed-modules:     Distribution.Helper
                        Distribution.Helper.Discover
   other-modules:
@@ -156,28 +167,25 @@ library
   autogen-modules:
                        Paths_cabal_helper
   hs-source-dirs:      lib
-  build-depends:       c-h-internal
 
 test-suite compile-test
-  import:              build-deps, extensions
+  import:              build-deps, extensions, c-h-internal
   type:                exitcode-stdio-1.0
   main-is:             CompileTest.hs
   other-modules:       TestOptions
   hs-source-dirs:      tests
   ghc-options:         -Wall
-  build-depends:       c-h-internal
 
 test-suite programs-test
-  import:              build-deps, extensions
+  import:              build-deps, extensions, c-h-internal
   type:                exitcode-stdio-1.0
   main-is:             ProgramsTest.hs
   hs-source-dirs:      tests
   ghc-options:         -Wall
-  build-depends:       c-h-internal
-                     , pretty-show
+  build-depends:       pretty-show
 
 test-suite ghc-session
-  import:              build-deps, extensions
+  import:              build-deps, extensions, c-h-lib
   type:                exitcode-stdio-1.0
   main-is:             GhcSession.hs
   other-modules:       TestOptions
@@ -185,16 +193,13 @@ test-suite ghc-session
   ghc-options:         -Wall
   build-depends:       ghc              < 8.9  && >= 8.0.2
                      , pretty-show      < 1.9  && >= 1.8.1
-                     , cabal-helper
-                     , c-h-internal
 
 test-suite examples
-  import:              build-deps, extensions
+  import:              build-deps, extensions, c-h-lib
   type:                exitcode-stdio-1.0
   main-is:             Examples.hs
   hs-source-dirs:      tests
   ghc-options:         -Wall
-  build-depends:       cabal-helper
 
 executable cabal-helper-main
   default-language:    Haskell2010


### PR DESCRIPTION
Private libraries have a bunch of bugs in cabal currently:
* https://github.com/haskell/cabal/issues/6211
* https://github.com/haskell/cabal/issues/6483

and devs of haskell-ide-engine are encountering this bug frequently.
To mitigate this issue, remove usage of private libraries and use
a common stanza to have the same re-use as before.

This change can be undone when the mentioned issues have been resolved.