### PR TITLE
Refactor Program versions handling

### DIFF
--- a/lib/Distribution/Helper.hs
+++ b/lib/Distribution/Helper.hs
@@ -312,7 +312,7 @@ unitInfo u = Query $ \qe -> getUnitInfo qe u
 
 -- | Get information on all units in a project.
 allUnits :: (UnitInfo -> a) -> Query pt (NonEmpty a)
-allUnits f = do
+allUnits f =
   fmap f <$> (T.mapM unitInfo =<< join . fmap pUnits <$> projectPackages)
 
 

--- a/src/CabalHelper/Compiletime/Compile.hs
+++ b/src/CabalHelper/Compiletime/Compile.hs
@@ -112,7 +112,7 @@ compileHelper'
     => CompHelperEnv' UnpackedCabalVersion
     -> IO (Either ExitCode FilePath)
 compileHelper' CompHelperEnv {..} = do
-  ghcVer <- ghcVersion
+  ghcVer <- GhcVersion <$> getGhcVersion
   Just (prepare, comp) <- case cheCabalVer of
     cabalVer@CabalHEAD {} -> runMaybeT $ msum  $ map (\f -> f ghcVer cabalVer)
       [ compileWithCabalV2GhcEnv'
@@ -217,7 +217,7 @@ compileHelper' CompHelperEnv {..} = do
    compileWithCabalV2GhcEnv' :: Env => GhcVersion -> UnpackedCabalVersion -> MaybeT IO (IO (), Compile)
    compileWithCabalV2GhcEnv' ghcVer cabalVer = do
        _ <- maybe mzero pure cheDistV2 -- bail if this isn't a v2-build project
-       CabalInstallVersion instVer <- liftIO cabalInstallVersion
+       instVer <- liftIO getCabalInstallVersion
        guard $ instVer >= (Version [2,4,1,0] [])
        --  ^ didn't test with older versions
        guard $ ghcVer  >= (GhcVersion (Version [8,0] []))

--- a/src/CabalHelper/Compiletime/Program/GHC.hs
+++ b/src/CabalHelper/Compiletime/Program/GHC.hs
@@ -60,16 +60,16 @@ newtype GhcVersion = GhcVersion { unGhcVersion :: Version }
 showGhcVersion :: GhcVersion -> String
 showGhcVersion (GhcVersion v) = showVersion v
 
-ghcVersion :: (Verbose, Progs) => IO GhcVersion
-ghcVersion = GhcVersion .
+getGhcVersion :: (Verbose, Progs) => IO Version
+getGhcVersion =
   parseVer . trim <$> readProcess' (ghcProgram ?progs) ["--numeric-version"] ""
 
 ghcLibdir :: (Verbose, Progs) => IO FilePath
 ghcLibdir = do
   trim <$> readProcess' (ghcProgram ?progs) ["--print-libdir"] ""
 
-ghcPkgVersion :: (Verbose, Progs) => IO Version
-ghcPkgVersion =
+getGhcPkgVersion :: (Verbose, Progs) => IO Version
+getGhcPkgVersion =
   parseVer . trim . dropWhile (not . isDigit)
     <$> readProcess' (ghcPkgProgram ?progs) ["--version"] ""
 
@@ -85,9 +85,9 @@ createPkgDb cabalVer = do
 getPrivateCabalPkgDb :: (Verbose, Progs) => ResolvedCabalVersion -> IO PackageDbDir
 getPrivateCabalPkgDb cabalVer = do
   appdir <- appCacheDir
-  ghcVer <- ghcVersion
+  ghcVer <- getGhcVersion
   let db_path =
-        appdir </> "ghc-" ++ showGhcVersion ghcVer ++ ".package-dbs"
+        appdir </> "ghc-" ++ showVersion ghcVer ++ ".package-dbs"
                </> "Cabal-" ++ showResolvedCabalVersion cabalVer
   return $ PackageDbDir db_path
 

--- a/src/CabalHelper/Compiletime/Program/Stack.hs
+++ b/src/CabalHelper/Compiletime/Program/Stack.hs
@@ -38,7 +38,12 @@ import Prelude
 
 import CabalHelper.Compiletime.Types
 import CabalHelper.Compiletime.Types.RelativePath
+import CabalHelper.Compiletime.Process
 import CabalHelper.Shared.Common
+
+getStackVersion :: (Verbose, Progs) => IO Version
+getStackVersion =
+  parseVer . trim <$> readProcess' (stackProgram ?progs) [ "--numeric-version" ] ""
 
 getPackage :: QueryEnvI c 'Stack -> CabalFile -> IO (Package 'Stack)
 getPackage qe cabal_file@(CabalFile cabal_file_path) = do

--- a/tests/CompileTest.hs
+++ b/tests/CompileTest.hs
@@ -72,7 +72,7 @@ main = do
 
   case args of
     "list-versions":[] -> do
-        mapM_ print =<< relevantCabalVersions =<< ghcVersion
+        mapM_ print =<< relevantCabalVersions =<< (GhcVersion <$> getGhcVersion)
     "list-versions":ghc_ver_str:[] ->
         mapM_ print =<< relevantCabalVersions (GhcVersion (parseVer ghc_ver_str))
     _ ->
@@ -125,7 +125,7 @@ allCabalVersions (GhcVersion ghc_ver) = do
 
 testRelevantCabalVersions :: Env => IO ()
 testRelevantCabalVersions = do
-  ghc_ver <- ghcVersion
+  ghc_ver <- GhcVersion <$> getGhcVersion
   relevant_cabal_versions <- relevantCabalVersions ghc_ver
   testCabalVersions $ map CabalVersion relevant_cabal_versions ++ [CabalHEAD ()]
 


### PR DESCRIPTION
This mainly renames the program version getters to get* and make them
consistenly return Version directly. Such that wrappers like GhcVersion
have to be added at the callsites of the relevant functions.