### PR TITLE
Append .exe to fix helper lookup in win

### DIFF
--- a/src/CabalHelper/Compiletime/Compile.hs
+++ b/src/CabalHelper/Compiletime/Compile.hs
@@ -327,7 +327,7 @@ compPaths appdir proj_local_cachedir c =
           compBuildDir =
             appdir </> exeName compCabalVersion ++ "--" ++ sourceHash <.> "build"
           compOutDir  = compBuildDir
-          compExePath = compBuildDir </> "cabal-helper"
+          compExePath = compBuildDir </> "cabal-helper" <.> exeExtension
     CompileWithCabalPackage {compProductTarget=CPSProject} ->
         projLocalCachedirPaths
     CompileWithCabalSource {} ->
@@ -337,7 +337,7 @@ compPaths appdir proj_local_cachedir c =
         where
           compBuildDir = proj_local_cachedir </> "cabal-helper"
           compOutDir  = compBuildDir
-          compExePath = compOutDir </> "cabal-helper"
+          compExePath = compOutDir </> "cabal-helper" <.> exeExtension
 
 exeName :: ResolvedCabalVersion -> String
 exeName (CabalHEAD commitid) = intercalate "--"


### PR DESCRIPTION
Now i get
```
using helper compiled with Cabal from v2-build package-env C:\Users\atrey\Local Settings\Cache\cabal-helper\ghc-8.8.3.package-envs\Cabal-3.2.0.0.package-env
helper already compiled, using exe: C:\Users\atrey\Local Settings\Cache\cabal-helper\cabal-helper-1.1.0.0--Cabal-3.2.0.0--642c18efd5657699c4a87dbd7ad05e3be3857a9df0526a676bd8d0a5fcce9476.build\cabal-helper.exe
compileHelper took 0.69509s
```