### PR TITLE
Remove allow-newer for cabal-plan

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,2 @@
 packages: .
 
--- Remove when cabal-plan supports ghc-8.10.1
--- see https://github.com/haskell-hvr/cabal-plan/issues/54
-allow-newer: cabal-plan:base


### PR DESCRIPTION
* A `cabal-plan` compatible with `ghc-8.10.1` has been released so there is no need for `allow-newer`