### PR TITLE
Allow cabal-plan compatible with ghc-8.10

### DIFF
--- a/cabal-helper.cabal
+++ b/cabal-helper.cabal
@@ -96,7 +96,7 @@ common build-deps
                      , Cabal            < 3.4  && >= 3.0
                                      || < 2.5  && >= 2.0
                                      || < 1.26 && >= 1.24.2.0
-                     , cabal-plan       < 0.7  && >= 0.5.0.0
+                     , cabal-plan       < 0.8  && >= 0.5.0.0
                      , clock            < 0.8  && >= 0.7.2
                      , containers       < 1    && >= 0.5.7.1
                      , bytestring       < 0.11 && >= 0.10.8.1


### PR DESCRIPTION
* Forgot to include this change in #121 so the project was unbuildable for ghc-8.10.1 as the ci and @DanielG catched 